### PR TITLE
Add u128/i128 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 0.3.0 ###
+* :star: Add u128/i128 read and write support (little-endian and big-endian).
+* Document panic-free design in README.
+* Use `into()` instead of `as` for widening conversions.
+
 ### 0.2.0 ###
 * Specify lints in Cargo.toml instead of lib.rs.
 * :star: Add method to `ReadCursor` to retrieve the position.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ unreachable_pub = "deny"
 trivial_casts = "deny"
 missing_docs = "deny"
 warnings = "deny"
-unused = "deny"
+unused = { level = "deny", priority = -1 }
 missing_copy_implementations = "deny"
 
 [lints.clippy]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scursor"
-version = "0.2.0"
+version = "0.3.0"
 license = "MIT OR Apache-2.0"
 edition = "2021"
 description = "Secure cursor library with support for read and write transactions"

--- a/README.md
+++ b/README.md
@@ -4,6 +4,36 @@
 
 Secure cursor library with support for read and write transactions.
 
+## Panic-free design
+
+`scursor` is designed to be strictly panic-free. This makes it suitable for parsing untrusted input
+in security-sensitive contexts, embedded systems with `panic = "abort"`, or anywhere predictable
+failure handling is required.
+
+The `ReadCursor` uses a consumption model where each read operation advances an internal position
+within a borrowed byte slice. The key insight is that all operations use inherently safe methods:
+
+```rust
+pub fn read_u8(&mut self) -> Result<u8, ReadError> {
+    match self.input.get(self.pos) {          // .get() returns Option, never panics
+        Some(x) => {
+            let pos = self.pos.checked_add(1) // checked_add() returns Option on overflow
+                .ok_or(ReadError)?;
+            self.pos = pos;
+            Ok(*x)
+        }
+        None => Err(ReadError),
+    }
+}
+```
+
+Larger types are composed from smaller reads. For example, `read_u32_le()` performs two `read_u16_le()`
+calls, which each perform two `read_u8()` calls. This hierarchical approach means panic-freedom is
+established at the leaf operations and preserved through composition.
+
+There are no direct slice indexing operations (`slice[i]`), no `.unwrap()` or `.expect()` calls,
+and no arithmetic that could overflow. Every failure path returns a `Result`.
+
 ## License
 Licensed under the terms of the MIT or Apache v2 licenses at your choice.
 

--- a/src/read.rs
+++ b/src/read.rs
@@ -100,8 +100,8 @@ impl<'a> ReadCursor<'a> {
 impl<'a> ReadCursor<'a> {
     /// Read a u16 from a little-endian representation
     pub fn read_u16_le(&mut self) -> Result<u16, ReadError> {
-        let low = self.read_u8()? as u16;
-        let high = self.read_u8()? as u16;
+        let low: u16 = self.read_u8()?.into();
+        let high: u16 = self.read_u8()?.into();
         Ok(high << 8 | low)
     }
 
@@ -112,8 +112,8 @@ impl<'a> ReadCursor<'a> {
 
     /// Read a u32 from a little-endian representation
     pub fn read_u32_le(&mut self) -> Result<u32, ReadError> {
-        let low = self.read_u16_le()? as u32;
-        let high = self.read_u16_le()? as u32;
+        let low: u32 = self.read_u16_le()?.into();
+        let high: u32 = self.read_u16_le()?.into();
         Ok(high << 16 | low)
     }
 
@@ -124,16 +124,15 @@ impl<'a> ReadCursor<'a> {
 
     /// Read a 48-bit unsigned number from a little-endian representation, store it in the first 6 bytes of a u64
     pub fn read_u48_le(&mut self) -> Result<u64, ReadError> {
-        let low = self.read_u32_le()? as u64;
-        let high = self.read_u16_le()? as u64;
+        let low: u64 = self.read_u32_le()?.into();
+        let high: u64 = self.read_u16_le()?.into();
         Ok(high << 32 | low)
     }
 
     /// Read a u64 number from a little-endian representation
     pub fn read_u64_le(&mut self) -> Result<u64, ReadError> {
-        let low = self.read_u32_le()? as u64;
-        let high = self.read_u32_le()? as u64;
-
+        let low: u64 = self.read_u32_le()?.into();
+        let high: u64 = self.read_u32_le()?.into();
         Ok(high << 32 | low)
     }
 
@@ -169,8 +168,8 @@ impl<'a> ReadCursor<'a> {
 impl<'a> ReadCursor<'a> {
     /// Read a u16 from a big-endian representation
     pub fn read_u16_be(&mut self) -> Result<u16, ReadError> {
-        let high = self.read_u8()? as u16;
-        let low = self.read_u8()? as u16;
+        let high: u16 = self.read_u8()?.into();
+        let low: u16 = self.read_u8()?.into();
         Ok(high << 8 | low)
     }
 
@@ -181,8 +180,8 @@ impl<'a> ReadCursor<'a> {
 
     /// Read a u32 from a big-endian representation
     pub fn read_u32_be(&mut self) -> Result<u32, ReadError> {
-        let high = self.read_u16_be()? as u32;
-        let low = self.read_u16_be()? as u32;
+        let high: u32 = self.read_u16_be()?.into();
+        let low: u32 = self.read_u16_be()?.into();
         Ok(high << 16 | low)
     }
 
@@ -193,8 +192,8 @@ impl<'a> ReadCursor<'a> {
 
     /// Read a u64 from a big-endian representation
     pub fn read_u64_be(&mut self) -> Result<u64, ReadError> {
-        let high = self.read_u32_be()? as u64;
-        let low = self.read_u32_be()? as u64;
+        let high: u64 = self.read_u32_be()?.into();
+        let low: u64 = self.read_u32_be()?.into();
         Ok(high << 32 | low)
     }
 

--- a/src/read.rs
+++ b/src/read.rs
@@ -142,6 +142,18 @@ impl<'a> ReadCursor<'a> {
         self.read_u64_le().map(|x| x as i64)
     }
 
+    /// Read a u128 number from a little-endian representation
+    pub fn read_u128_le(&mut self) -> Result<u128, ReadError> {
+        let low: u128 = self.read_u64_le()?.into();
+        let high: u128 = self.read_u64_le()?.into();
+        Ok(high << 64 | low)
+    }
+
+    /// Read a i128 number from a little-endian representation
+    pub fn read_i128_le(&mut self) -> Result<i128, ReadError> {
+        self.read_u128_le().map(|x| x as i128)
+    }
+
     /// Read an IEEE-754 f32 from a little-endian representation
     pub fn read_f32_le(&mut self) -> Result<f32, ReadError> {
         Ok(f32::from_bits(self.read_u32_le()?))
@@ -189,6 +201,18 @@ impl<'a> ReadCursor<'a> {
     /// Read a i64 from a big-endian representation
     pub fn read_i64_be(&mut self) -> Result<i64, ReadError> {
         self.read_u64_be().map(|x| x as i64)
+    }
+
+    /// Read a u128 from a big-endian representation
+    pub fn read_u128_be(&mut self) -> Result<u128, ReadError> {
+        let high: u128 = self.read_u64_be()?.into();
+        let low: u128 = self.read_u64_be()?.into();
+        Ok(high << 64 | low)
+    }
+
+    /// Read a i128 from a big-endian representation
+    pub fn read_i128_be(&mut self) -> Result<i128, ReadError> {
+        self.read_u128_be().map(|x| x as i128)
     }
 }
 
@@ -284,5 +308,33 @@ mod tests {
         let mut cursor = ReadCursor::new(&[0x01, 0x00, 0xFF, 0xEE, 0xDD, 0xCC, 0xBB, 0xAA]);
         assert_eq!(cursor.read_u64_be().unwrap(), 0x0100FFEEDDCCBBAA);
         assert_eq!(cursor.remaining(), 0);
+    }
+
+    #[test]
+    fn can_read_u128_le() {
+        let mut cursor = ReadCursor::new(&[
+            0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D,
+            0x0E, 0x0F,
+        ]);
+        assert_eq!(
+            cursor.read_u128_le().unwrap(),
+            0x0F0E0D0C0B0A09080706050403020100
+        );
+        assert_eq!(cursor.remaining(), 0);
+        assert_eq!(cursor.position(), 16);
+    }
+
+    #[test]
+    fn can_read_u128_be() {
+        let mut cursor = ReadCursor::new(&[
+            0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D,
+            0x0E, 0x0F,
+        ]);
+        assert_eq!(
+            cursor.read_u128_be().unwrap(),
+            0x000102030405060708090A0B0C0D0E0F
+        );
+        assert_eq!(cursor.remaining(), 0);
+        assert_eq!(cursor.position(), 16);
     }
 }

--- a/src/write.rs
+++ b/src/write.rs
@@ -186,12 +186,32 @@ impl<'a> WriteCursor<'a> {
     pub fn write_f64_le(&mut self, value: f64) -> Result<(), WriteError> {
         self.write_bytes(&value.to_le_bytes())
     }
+
+    /// Write a u128 in little-endian format
+    pub fn write_u128_le(&mut self, value: u128) -> Result<(), WriteError> {
+        self.write_bytes(&value.to_le_bytes())
+    }
+
+    /// Write a i128 in little-endian format
+    pub fn write_i128_le(&mut self, value: i128) -> Result<(), WriteError> {
+        self.write_bytes(&value.to_le_bytes())
+    }
 }
 
 /// big-endian write routines
 impl<'a> WriteCursor<'a> {
     /// Write a u16 in big-endian format
     pub fn write_u16_be(&mut self, value: u16) -> Result<(), WriteError> {
+        self.write_bytes(&value.to_be_bytes())
+    }
+
+    /// Write a u128 in big-endian format
+    pub fn write_u128_be(&mut self, value: u128) -> Result<(), WriteError> {
+        self.write_bytes(&value.to_be_bytes())
+    }
+
+    /// Write a i128 in big-endian format
+    pub fn write_i128_be(&mut self, value: i128) -> Result<(), WriteError> {
         self.write_bytes(&value.to_be_bytes())
     }
 }
@@ -250,5 +270,37 @@ mod test {
         );
 
         assert_eq!(cursor.written(), &[0x00, 0x00, 0xFF]);
+    }
+
+    #[test]
+    fn can_write_u128_le() {
+        let mut buffer = [0u8; 16];
+        let mut cursor = WriteCursor::new(&mut buffer);
+        cursor
+            .write_u128_le(0x0F0E0D0C0B0A09080706050403020100)
+            .unwrap();
+        assert_eq!(
+            cursor.written(),
+            &[
+                0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D,
+                0x0E, 0x0F
+            ]
+        );
+    }
+
+    #[test]
+    fn can_write_u128_be() {
+        let mut buffer = [0u8; 16];
+        let mut cursor = WriteCursor::new(&mut buffer);
+        cursor
+            .write_u128_be(0x000102030405060708090A0B0C0D0E0F)
+            .unwrap();
+        assert_eq!(
+            cursor.written(),
+            &[
+                0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D,
+                0x0E, 0x0F
+            ]
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Add u128/i128 read and write support (little-endian and big-endian)
- Document panic-free design in README
- Use `into()` instead of `as` for widening conversions
- Prepare release 0.3.0